### PR TITLE
Update index.jsp

### DIFF
--- a/projects/web-client/source/web/index.jsp
+++ b/projects/web-client/source/web/index.jsp
@@ -62,7 +62,7 @@ TransactionService transactionService = (TransactionService)context.getBean("tra
             <p></p>
             <p><a href="http://docs.alfresco.com/">Online Documentation</a></p>
             <p></p>
-            <p><a href="<%=UrlUtil.getShareUrl(sysAdminParams)%>">Alfresco Share</a></p>
+            <p><a href="../share">Alfresco Share</a></p>
             <p><a href="./webdav">Alfresco WebDav</a></p>
             <p></p>
             <p><a href="./s/index">Alfresco WebScripts Home</a> (admin only)</p>


### PR DESCRIPTION

![suggest-change index jsp](https://cloud.githubusercontent.com/assets/2724141/8645502/2060f5fc-2972-11e5-9a50-5737b8801557.PNG)
By this way "<%=UrlUtil.getShareUrl(sysAdminParams)%>", it always returns to "share.host= 127.0.0.1" in file /path/to/alfresco-5.0.d/tomcat/shared/classes/alfresco-global.properties 
Should change to "../share" to get the server ip