### PR TITLE
More helpful exceptions from SiteMembership

### DIFF
--- a/projects/repository/source/java/org/alfresco/repo/site/SiteMembership.java
+++ b/projects/repository/source/java/org/alfresco/repo/site/SiteMembership.java
@@ -44,19 +44,19 @@ public class SiteMembership
 		}
 		if(personId == null)
 		{
-			throw new java.lang.IllegalArgumentException();
+			throw new java.lang.IllegalArgumentException("Person required building site membership of " + siteInfo.getShortName());
 		}
 		if(firstName == null)
 		{
-			throw new java.lang.IllegalArgumentException();
+			throw new java.lang.IllegalArgumentException("Firstname required building site membership of " + siteInfo.getShortName());
 		}
 		if(lastName == null)
 		{
-			throw new java.lang.IllegalArgumentException();
+			throw new java.lang.IllegalArgumentException("Lastname required building site membership of " + siteInfo.getShortName());
 		}
 		if(role == null)
 		{
-			throw new java.lang.IllegalArgumentException();
+			throw new java.lang.IllegalArgumentException("Role required building site membership of " + siteInfo.getShortName() + " for " + personId);
 		}
 		this.siteInfo = siteInfo;
 		this.personId = personId;
@@ -74,11 +74,11 @@ public class SiteMembership
 		}
 		if(personId == null)
 		{
-			throw new java.lang.IllegalArgumentException();
+			throw new java.lang.IllegalArgumentException("Person required building site membership of " + siteInfo.getShortName());
 		}
 		if(role == null)
 		{
-			throw new java.lang.IllegalArgumentException();
+			throw new java.lang.IllegalArgumentException("Role required building site membership of " + siteInfo.getShortName() + " for " + personId);
 		}
 
 		this.siteInfo = siteInfo;


### PR DESCRIPTION
When SiteMembership decides that the parameters passed to its constructors
are invalid, it is more helpful for administrators trying to fix broken
membership details if they know what site the problem is for. So, replace the
naked IllegalArgumentException throws with more helpful ones which inform
(where possible) what site the problem has triggered for