### PR TITLE
Dialect for h2. It let to do an export in a default amp project

### DIFF
--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/activities-insert-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/activities-insert-SqlMap.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="alfresco.activities.insert">
+
+   <insert id="insert_activity_feedcontrol" parameterType="FeedControl">
+      
+      <selectKey keyProperty="id" resultType="long" order="BEFORE" >
+         select nextVal('alf_activity_feed_control_seq')
+      </selectKey>
+      
+      <include refid="alfresco.activities.insert_ActivityFeedControl_Sequence"/>
+      
+   </insert>
+   
+   <insert id="insert_activity_feed" parameterType="ActivityFeed">
+      
+      <selectKey keyProperty="id" resultType="long" order="BEFORE" >
+         select nextVal('alf_activity_feed_seq')
+      </selectKey>
+      
+      <include refid="alfresco.activities.insert_ActivityFeed_Sequence"/>
+      
+   </insert>
+   
+   <insert id="insert_activity_post" parameterType="ActivityPost">
+      
+      <selectKey keyProperty="id" resultType="long" order="BEFORE" >
+         select nextVal('alf_activity_post_seq')
+      </selectKey>
+      
+      <include refid="alfresco.activities.insert_ActivityPost_Sequence"/>
+      
+   </insert>
+   
+</mapper>

--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/audit-insert-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/audit-insert-SqlMap.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="alfresco.audit.insert">
+
+    <insert id="insert_AuditModel" parameterType="AuditModel" >
+        
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_audit_model_seq')
+        </selectKey>
+        
+        <include refid="alfresco.audit.insert_AuditModel_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_AuditApplication" parameterType="AuditApplication" >
+        
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_audit_app_seq')
+        </selectKey>
+        
+        <include refid="alfresco.audit.insert_AuditApplication_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_AuditEntry" parameterType="AuditEntry" >
+        
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_audit_entry_seq')
+        </selectKey>
+        
+        <include refid="alfresco.audit.insert_AuditEntry_Sequence"/>
+        
+    </insert>
+    
+</mapper>

--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/audit-select-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/audit-select-SqlMap.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!-- 
+   Dialect: Postgres
+-->
+<mapper namespace="alfresco.audit">
+
+    <!-- Get audit entries -->
+    <select id="select_AuditEntriesWithoutValues" parameterType="AuditQueryParameters" resultMap="result_AuditQueryNoValues">
+        <include refid="select_AuditEntriesWithoutValuesCommon"/>
+    </select>
+
+    <select id="select_AuditEntriesWithValues" parameterType="AuditQueryParameters" resultMap="result_AuditQueryAllValues">
+        <include refid="select_AuditEntriesWithValuesCommon"/>
+    </select>
+
+</mapper>

--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/content-insert-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/content-insert-SqlMap.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="alfresco.content.insert">
+   
+   <insert id="insert_Mimetype" parameterType="Mimetype" >
+        
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_mimetype_seq')
+        </selectKey>
+        
+        <include refid="alfresco.content.insert_Mimetype_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_Encoding" parameterType="Encoding" >
+    
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+             select nextVal('alf_encoding_seq')
+        </selectKey>
+        
+        <include refid="alfresco.content.insert_Encoding_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_ContentUrl" parameterType="ContentUrl" >
+        
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_content_url_seq')
+        </selectKey>
+        
+         <include refid="alfresco.content.insert_ContentUrl_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_ContentData" parameterType="ContentData" >
+    
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_content_data_seq')
+        </selectKey>
+        
+        <include refid="alfresco.content.insert_ContentData_Sequence"/>
+        
+    </insert>
+
+    <insert id="insert_KeyData" parameterType="ContentUrlKey">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_content_url_enc_seq')
+        </selectKey>
+
+        <include refid="alfresco.content.insert_KeyData_Sequence"/>
+    </insert>
+</mapper>

--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/locale-insert-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/locale-insert-SqlMap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="alfresco.locale.insert">
+
+    <insert id="insert_Locale" parameterType="Locale">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_locale_seq')
+        </selectKey>
+        
+        <include refid="alfresco.locale.insert_Locale_Sequence"/>
+    </insert>
+    
+</mapper>

--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/locks-insert-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/locks-insert-SqlMap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="alfresco.lock.insert">
+
+    <insert id="insert_LockResource" parameterType="LockResource" >
+    
+       <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_lock_resource_seq')
+        </selectKey>
+        
+        <include refid="alfresco.lock.insert_LockResource_Sequence"/>
+        
+    </insert>
+
+    <insert id="insert_Lock" parameterType="Lock" >
+    
+       <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_lock_seq')
+        </selectKey>
+        
+        <include refid="alfresco.lock.insert_Lock_Sequence"/>
+        
+    </insert>
+
+</mapper>

--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/node-insert-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/node-insert-SqlMap.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="alfresco.node.insert">
+
+    <insert id="insert_Server" parameterType="Server" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_server_seq')
+        </selectKey>
+        
+        <include refid="alfresco.node.insert_Server_Sequence"/>
+    </insert>
+
+    <insert id="insert_Store" parameterType="Store" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_store_seq')
+        </selectKey>
+        
+        <include refid="alfresco.node.insert_Store_Sequence"/>
+    </insert>
+
+    <insert id="insert_Node" parameterType="Node" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_node_seq')
+        </selectKey>
+        
+        <include refid="alfresco.node.insert_Node_Sequence"/>
+    </insert>
+
+    <insert id="insert_Transaction" parameterType="Transaction" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_transaction_seq')
+        </selectKey>
+        
+        <include refid="alfresco.node.insert_Transaction_Sequence"/>
+    </insert>
+
+    <insert id="insert_NodeAssoc" parameterType="NodeAssoc" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_node_assoc_seq')
+        </selectKey>
+        
+        <include refid="alfresco.node.insert_NodeAssoc_Sequence"/>
+    </insert>
+
+    <insert id="insert_ChildAssoc" parameterType="ChildAssoc" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_child_assoc_seq')
+        </selectKey>
+        
+        <include refid="alfresco.node.insert_ChildAssoc_Sequence"/>
+        
+    </insert>
+
+</mapper>

--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/permissions-insert-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/permissions-insert-SqlMap.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="alfresco.permissions.insert">
+
+    <insert id="insert_Acl" parameterType="Acl">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE">
+            select nextVal('alf_access_control_list_seq')
+        </selectKey>
+        
+        <include refid="alfresco.permissions.insert_Acl_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_AclMember" parameterType="AclMember">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE">
+            select nextVal('alf_acl_member_seq')
+        </selectKey>
+        
+        <include refid="alfresco.permissions.insert_AclMember_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_AclChangeSet" parameterType="AclChangeSet">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_acl_change_set_seq')
+        </selectKey>
+        
+        <include refid="alfresco.permissions.insert_AclChangeSet_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_Ace" parameterType="Ace">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_access_control_entry_seq')
+        </selectKey>
+        
+        <include refid="alfresco.permissions.insert_Ace_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_AceContext" parameterType="AceContext">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_ace_context_seq')
+        </selectKey>
+        
+        <include refid="alfresco.permissions.insert_AceContext_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_Permission" parameterType="Permission">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_permission_seq')
+        </selectKey>
+        
+        <include refid="alfresco.permissions.insert_Permission_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_Authority" parameterType="Authority">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_authority_seq')
+        </selectKey>
+        
+        <include refid="alfresco.permissions.insert_Authority_Sequence"/>
+        
+    </insert>
+    
+    <insert id="insert_AuthorityAlias" parameterType="AuthorityAlias">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_authority_alias_seq')
+        </selectKey>
+        
+        <include refid="alfresco.permissions.insert_AuthorityAlias_Sequence"/>
+        
+    </insert>
+    
+</mapper>

--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/propval-insert-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/propval-insert-SqlMap.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="alfresco.propval.insert">
+
+    <insert id="insert_PropertyClass" parameterType="PropertyClass" >
+        <selectKey resultType=
+        "long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_prop_class_seq')
+        </selectKey>
+        <include refid="alfresco.propval.insert_PropertyClass_Sequence"/>
+    </insert>
+
+    <insert id="insert_PropertyStringValue" parameterType="PropertyStringValue" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_prop_string_value_seq')
+        </selectKey>
+        <include refid="alfresco.propval.insert_PropertyStringValue_Sequence"/>
+    </insert>
+
+    <insert id="insert_PropertyDoubleValue" parameterType="PropertyDoubleValue" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_prop_double_value_seq')
+        </selectKey>
+        <include refid="alfresco.propval.insert_PropertyDoubleValue_Sequence"/>
+    </insert>
+
+    <insert id="insert_PropertySerializableValue" parameterMap="alfresco.propval.parameter_IdPropertySerializableValue" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_prop_serializable_value_seq')
+        </selectKey>
+        <include refid="alfresco.propval.insert_PropertySerializableValue_Sequence"/>
+    </insert>
+
+    <insert id="insert_PropertyValue" parameterType="PropertyValue" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_prop_value_seq')
+        </selectKey>
+        <include refid="alfresco.propval.insert_PropertyValue_Sequence"/>
+    </insert>
+
+    <insert id="insert_PropertyRoot" parameterMap="alfresco.propval.parameter_IdPropertyRoot" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_prop_root_seq')
+        </selectKey>
+        <include refid="alfresco.propval.insert_PropertyRoot_Sequence"/>
+    </insert>
+
+    <insert id="insert_PropertyUniqueContext" parameterType="PropertyUniqueContext" >
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_prop_unique_ctx_seq')
+        </selectKey>
+        <include refid="alfresco.propval.insert_PropertyUniqueContext_Sequence"/>
+    </insert>
+
+</mapper>

--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/qname-insert-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/qname-insert-SqlMap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="alfresco.qname.insert">
+
+    <insert id="insert_Namespace" parameterType="Namespace" >
+    	<selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_namespace_seq')
+        </selectKey>
+    
+        <include refid="alfresco.qname.insert_Namespace_Sequence"/>
+    </insert>
+
+    <insert id="insert_QName" parameterType="QName" >
+    	<selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_qname_seq')
+        </selectKey>
+        
+        <include refid="alfresco.qname.insert_QName_AutoIncrement_Sequence"/>
+        
+    </insert>
+
+</mapper>

--- a/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/usage-insert-SqlMap.xml
+++ b/projects/repository/config/alfresco/ibatis/org.hibernate.dialect.H2Dialect/usage-insert-SqlMap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="alfresco.usage.insert">
+
+    <insert id="insert_UsageDelta" parameterType="UsageDelta">
+        <selectKey resultType="long" keyProperty="id" order="BEFORE" >
+            select nextVal('alf_usage_delta_seq')
+        </selectKey>
+    
+        <include refid="alfresco.usage.insert_UsageDelta_Sequence"/>
+    </insert>
+    
+</mapper>


### PR DESCRIPTION
I add the h2 scripts in the repository project. With it an export from an Alfresco configured with a h2 database is possible. It could be useful for develope and debug.

To test the updtae I start an export using the main method of the org.alfresco.tools.Export class with:

application parameters:
-user admin -pwd admin -s workspace://SpacesStore -p /app:company_home -verbose -root -zip my_acp -

vm parameters:
Xms128m -Xmx1024m -XX:MaxMetaspaceSize=256m -server -Dvti.server.port=0 -Dcifs.enabled=false -Dftp.enabled=false -Dnfs.enabled=false -Demail.server.enabled=false -Dldap.synchronization.active=false -Dimap.server.enabled=false -Daudit.enabled=false -Dtransferservice.receiver.enabled=false -Dalfresco.rmi.services.port=0 -Dooo.enabled=false -Dooo.exe= -Djodconverter.enabled=false 

additional classpath: 
com/h2database/h2/1.4.190/h2-1.4.190.jar